### PR TITLE
Add per-key IGNORE_MOD_TAP_INTERRUPT feature

### DIFF
--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -143,6 +143,8 @@ If you define these options you will enable the associated feature, which may in
 * `#define IGNORE_MOD_TAP_INTERRUPT`
   * makes it possible to do rolling combos (zx) with keys that convert to other keys on hold, by enforcing the `TAPPING_TERM` for both keys.
   * See [Mod tap interrupt](feature_advanced_keycodes.md#ignore-mod-tap-interrupt) for details
+* `#define IGNORE_MOD_TAP_INTERRUPT_PER_KEY`
+  * enables handling for per key `IGNORE_MOD_TAP_INTERRUPT` settings
 * `#define TAPPING_FORCE_HOLD`
   * makes it possible to use a dual role key as modifier shortly after having been tapped
   * See [Hold after tap](feature_advanced_keycodes.md#tapping-force-hold)

--- a/docs/custom_quantum_functions.md
+++ b/docs/custom_quantum_functions.md
@@ -489,14 +489,24 @@ The `val` is the value of the data that you want to write to EEPROM.  And the `e
 
 # Custom Tapping Term
 
-By default, the tapping term is defined globally, and is not configurable by key.  For most users, this is perfectly fine.  But in come cases, dual function keys would be greatly improved by different timeouts than `LT` keys, or because some keys may be easier to hold than others.  Instead of using custom key codes for each, this allows for per key configurable `TAPPING_TERM`.
+By default, the tapping term and related options (such as `IGNORE_MOD_TAP_INTERRUPT`) are defined globally, and are not configurable by key.  For most users, this is perfectly fine.  But in some cases, dual function keys would be greatly improved by different timeout behaviors than `LT` keys, or because some keys may be easier to hold than others.  Instead of using custom key codes for each, this allows for per key configurable timeout behaviors.
 
-To enable this functionality, you need to add `#define TAPPING_TERM_PER_KEY` to your `config.h`, first. 
+There are two configurable options to control per-key timeout behaviors:
+
+- `TAPPING_TERM_PER_KEY`
+- `IGNORE_MOD_TAP_INTERRUPT_PER_KEY`
+
+You need to add `#define` lines to your `config.h` for each feature you want.
+
+```
+#define TAPPING_TERM_PER_KEY
+#define IGNORE_MOD_TAP_INTERRUPT_PER_KEY
+```
 
 
 ## Example `get_tapping_term` Implementation
 
-To change the `TAPPING TERM` based on the keycode, you'd want to add something like the following to your `keymap.c` file: 
+To change the `TAPPING_TERM` based on the keycode, you'd want to add something like the following to your `keymap.c` file:
 
 ```c
 uint16_t get_tapping_term(uint16_t keycode) {
@@ -511,6 +521,21 @@ uint16_t get_tapping_term(uint16_t keycode) {
 }
 ```
 
-### `get_tapping_term` Function Documentation
+## Example `get_ignore_mod_tap_interrupt` Implementation
 
-Unlike many of the other functions here, there isn't a need (or even reason) to have a quantum or keyboard level function. Only a user level function is useful here, so no need to mark it as such.
+To change the `IGNORE_MOD_TAP_INTERRUPT` value based on the keycode, you'd want to add something like the following to your `keymap.c` file:
+
+```c
+bool get_ignore_mod_tap_interrupt(uint16_t keycode) {
+  switch (keycode) {
+    case SFT_T(KC_SPC):
+      return true;
+    default:
+      return false;
+  }
+}
+```
+
+## `get_tapping_term` / `get_ignore_mod_tap_interrupt` Function Documentation
+
+Unlike many of the other functions here, there isn't a need (or even reason) to have a quantum or keyboard level function. Only user level functions are useful here, so no need to mark them as such.

--- a/docs/ja/config_options.md
+++ b/docs/ja/config_options.md
@@ -148,6 +148,8 @@ QMK での全ての利用可能な設定にはデフォルトがあります。�
 * `#define IGNORE_MOD_TAP_INTERRUPT`
    * 両方のキーに `TAPPING_TERM` を適用することで、ホールド時に他のキーに変換するキーを使ってローリングコンボ (zx) をすることができるようにします
    * 詳細は [Mod tap interrupt](ja/feature_advanced_keycodes.md#ignore-mod-tap-interrupt) を見てください
+* `#define IGNORE_MOD_TAP_INTERRUPT_PER_KEY`
+   * キーごとの `IGNORE_MOD_TAP_INTERRUPT` 設定の処理を有効にします
 * `#define TAPPING_FORCE_HOLD`
    * タップされた直後に、デュアルロールキーを修飾子として使用できるようにします
    * [Hold after tap](ja/feature_advanced_keycodes.md#tapping-force-hold)を見てください

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -47,6 +47,10 @@ int retro_tapping_counter = 0;
 #    include <fauxclicky.h>
 #endif
 
+#ifdef IGNORE_MOD_TAP_INTERRUPT_PER_KEY
+__attribute__ ((weak)) bool get_ignore_mod_tap_interrupt(uint16_t keycode) { return false; }
+#endif
+
 #ifndef TAP_CODE_DELAY
 #    define TAP_CODE_DELAY 0
 #endif
@@ -308,8 +312,12 @@ void process_action(keyrecord_t *record, action_t action) {
                 default:
                     if (event.pressed) {
                         if (tap_count > 0) {
-#    ifndef IGNORE_MOD_TAP_INTERRUPT
-                            if (record->tap.interrupted) {
+#    if !defined(IGNORE_MOD_TAP_INTERRUPT) || defined(IGNORE_MOD_TAP_INTERRUPT_PER_KEY)
+                            if (
+#        ifdef IGNORE_MOD_TAP_INTERRUPT_PER_KEY
+                                !get_ignore_mod_tap_interrupt(get_event_keycode(record->event)) &&
+#        endif
+                                record->tap.interrupted) {
                                 dprint("mods_tap: tap: cancel: add_mods\n");
                                 // ad hoc: set 0 to cancel tap
                                 record->tap.count = 0;


### PR DESCRIPTION
## Description

This PR adds the `IGNORE_MOD_TAP_INTERRUPT_PER_KEY` feature, as like `TAPPING_TERM_PER_KEY`.

The feature may be quite useful for keyboards with few keys (say, 30% or so).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

I have confirmed as follows that this patch does not break anything:

```
git checkout qmk/master
make ergo42/rev1:default # IGNORE_MOD_TAP_INTERRUPT IS NOT enabled
make treadstone32:default # IGNORE_MOD_TAP_INTERRUPT IS enabled
mv ergo42_rev1_default.hex ergo42_rev1_default_MASTER.hex
mv treadstone32_default.hex treadstone32_default_MASTER.hex

git checkout pr_ignore_mod_tap_interrupt_per_key
make ergo42/rev1:default
make treadstone32:default

diff ergo42_rev1_default.hex ergo42_rev1_default_MASTER.hex # shows nothing
diff treadstone32_default.hex treadstone32_default_MASTER.hex # shows nothing
```